### PR TITLE
Added explicit __getstate__ and __setstate__ to enable pickling

### DIFF
--- a/clever/__init__.py
+++ b/clever/__init__.py
@@ -418,6 +418,14 @@ class APIRequestor(object):
 class CleverObject(object):
   _permanent_attributes = set(['api_key'])
 
+  # Adding these to enable pickling
+  # http://docs.python.org/2/library/pickle.html#pickling-and-unpickling-normal-class-instances
+  def __getstate__(self): 
+    return self.__dict__
+
+  def __setstate__(self, d):
+    self.__dict__.update(d)
+
   def __init__(self, id=None, api_key=None):
     self.__dict__['_values'] = set()
     self.__dict__['_unsaved_values'] = set()


### PR DESCRIPTION
Clever object unpickling fails with 

```
  File "/cygdrive/c/Users/Hardik/code/clever/__init__.py", line 455, in __getattr__
   if k in self._transient_values:
```

up till max recursion depth.

Adding `__getstate__` and `__setstate__` fixes this.

However, I'm not sure if  `__setstate__` would result in missing `__setattr__` updates, if it is called as a result of anything other than unpickling.
