### PR TITLE
Changed put to patch after support for put was deprecated

### DIFF
--- a/clever/__init__.py
+++ b/clever/__init__.py
@@ -731,7 +731,7 @@ class UpdateableAPIResource(APIResource):
       for k in self._unsaved_values:
         params[k] = getattr(self, k)
       url = self.instance_url()
-      response, auth = requestor.request('put', url, params)
+      response, auth = requestor.request('patch', url, params)
       self.refresh_from(response['data'], auth)
     else:
       logger.debug("Trying to save already saved object %r" % (self, ))


### PR DESCRIPTION
Put should be changed to patch. Put is no longer supported by clever-python
