### PR TITLE
Make the CLI clever script work + tests

### DIFF
--- a/bin/clever
+++ b/bin/clever
@@ -27,9 +27,9 @@ class APIResourceClient(object):
   def logged_curl(self, method, url, params):
     dict_params = self.to_dict(params)
     self.log_request(method, url, params, dict_params)
-    rbody, rcode, _ = clever.APIRequestor().request_raw(method, url, dict_params)
-    self.log_result(rbody, rcode)
-    return rbody, rcode
+    res, auth = clever.APIRequestor().request_raw(method, url, dict_params)
+    self.log_result(res['body'], res['code'])
+    return res['body'], res['code']
 
   def log_request(self, method, url, ordered_params, dict_params):
     if method.lower() == 'get':
@@ -46,7 +46,9 @@ class APIResourceClient(object):
       term = ' \\'
     else:
       term = ''
-    curl = ['curl %s%s -H "Authorization: Basic %s"%s' % (clever.api_base, url, base64.b64encode(clever.api_key), term)]
+    api_key = clever.get_api_key()
+    curl = ['curl %s%s -H "Authorization: Basic %s"%s' %
+            (clever.api_base, url, base64.b64encode(api_key), term)]
     if isinstance(ordered_params, list):
       for i, (k, v) in enumerate(ordered_params):
         if i == len(ordered_params) - 1:
@@ -170,11 +172,11 @@ event
 
   klass_name = args[0]
   method_name = args[1]
-
-  clever.api_key = opts.api_key or os.environ.get('CLEVER_API_KEY')
-  if not clever.api_key:
+  api_key = opts.api_key or os.environ.get('CLEVER_API_KEY')
+  if not api_key:
     parser.error('No API key provided (use -k option or set the CLEVER_API_KEY environment variable')
     return 1
+  clever.set_api_key(api_key)
 
   if opts.api_base:
     clever.api_base = opts.api_base

--- a/test/test_cli_clever.py
+++ b/test/test_cli_clever.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+
+import os
+import unittest
+import subprocess
+
+CLI_CLEVER = os.path.join(os.path.dirname(__file__), '../bin/clever ')
+
+class CleverCLITestCase(unittest.TestCase):
+
+  def run_clever(self, args='', env=None):
+    """
+    Runs the cli clever script, passes supplied args.
+    """
+    process = subprocess.Popen(CLI_CLEVER + args, shell=True, env=env,
+                               stdout=subprocess.PIPE,
+                               stderr=subprocess.PIPE)
+    
+    out, err = process.communicate()
+    code = process.returncode
+    return out, err, code
+
+  def test_help(self):
+    # Test help on error
+    out, err, code = self.run_clever()
+    self.assertEqual(code, 1)
+    # Test help on option
+    out, err, code = self.run_clever('-h')
+    self.assertEqual(code, 0)
+
+  def test_api_key(self):
+    # Check for error when key is not provided
+    out, err, code = self.run_clever('district all')
+    self.assertEqual(code, 2)
+    # Check for no error when key is provided via -k
+    out, err, code = self.run_clever('district all -k DEMO_KEY')
+    self.assertEqual(code, 0)
+    # Check for no error when key is provided via CLEVER_API_KEY
+    env = {'CLEVER_API_KEY':'DEMO_KEY'}
+    out, err, code = self.run_clever('district all', env)
+    self.assertEqual(code, 0)


### PR DESCRIPTION
The CLI clever is broken.
```
$ bin/clever district all -k DEMO_KEY
Running the equivalent of:
--
curl https://api.clever.com/v1.1/districts -H "Authorization: Basic REVNT19LRVk="
--
Traceback (most recent call last):
  File "bin/clever", line 211, in <module>
    sys.exit(main())
  File "bin/clever", line 208, in main
    return method(params)
  File "bin/clever", line 83, in all
    self.logged_curl('get', url, params)
  File "bin/clever", line 30, in logged_curl
    rbody, rcode, _ = clever.APIRequestor().request_raw(method, url, dict_params)
  File "bin/../clever/__init__.py", line 247, in request_raw
    raise AuthenticationError('Must provide either api_key or token auth. {}'.format(my_auth))
clever.AuthenticationError: Must provide either api_key or token auth. {}
```
These commits fix the problem and add two tests.