### PR TITLE
Fix CLI 'APIRequestor' object has no attribute 'encode' plus return failure on HTTP status!=200

### DIFF
--- a/bin/clever
+++ b/bin/clever
@@ -2,8 +2,6 @@
 import logging
 import optparse
 import os
-import re
-import subprocess
 import sys
 import base64
 
@@ -33,9 +31,8 @@ class APIResourceClient(object):
 
   def log_request(self, method, url, ordered_params, dict_params):
     if method.lower() == 'get':
-      requestor = clever.APIRequestor()
       if dict_params:
-        url = '%s?%s' % (url, clever.APIRequestor().encode(dict_params))
+        url = '%s?%s' % (url, clever.APIRequestor().urlencode(dict_params))
       ordered_params = []
     elif not ordered_params:
       ordered_params = '  -X %s' % (method.upper(), )

--- a/bin/clever
+++ b/bin/clever
@@ -27,7 +27,8 @@ class APIResourceClient(object):
     self.log_request(method, url, params, dict_params)
     res, auth = clever.APIRequestor().request_raw(method, url, dict_params)
     self.log_result(res['body'], res['code'])
-    return res['body'], res['code']
+
+    return res['code']
 
   def log_request(self, method, url, ordered_params, dict_params):
     if method.lower() == 'get':
@@ -74,27 +75,27 @@ class APIResourceClient(object):
 
   def retrieve(self, params):
     url = self.instance_url()
-    self.logged_curl('get', url, [])
+    return self.logged_curl('get', url, [])
 
 class ListableAPIResourceClient(APIResourceClient):
   def all(self, params):
     url = self.class_url()
-    self.logged_curl('get', url, params)
+    return self.logged_curl('get', url, params)
 
 class CreateableAPIResourceClient(APIResourceClient):
   def create(self, params):
     url = self.class_url()
-    self.logged_curl('post', url, params)
+    return self.logged_curl('post', url, params)
 
 class UpdateableAPIResourceClient(APIResourceClient):
   def update(self, params):
     url = self.instance_url()
-    self.logged_curl('patch', url, params)
+    return self.logged_curl('patch', url, params)
 
 class DeletableAPIResourceClient(APIResourceClient):
   def delete(self, params):
     url = self.instance_url()
-    self.logged_curl('delete', url, params)
+    return self.logged_curl('delete', url, params)
 
 # API objects
 class DistrictClient(ListableAPIResourceClient):
@@ -204,7 +205,9 @@ event
     parser.error('Invalid method %s of %s' % (method_name, klass_name))
     return 1
 
-  return method(params)
+  http_code = method(params)
+  # Return 0 only on success.
+  return 0 if http_code == 200 else 1
 
 if __name__ == '__main__':
   sys.exit(main())

--- a/test/test_cli_clever.py
+++ b/test/test_cli_clever.py
@@ -15,7 +15,7 @@ class CleverCLITestCase(unittest.TestCase):
     process = subprocess.Popen(CLI_CLEVER + args, shell=True, env=env,
                                stdout=subprocess.PIPE,
                                stderr=subprocess.PIPE)
-    
+
     out, err = process.communicate()
     code = process.returncode
     return out, err, code
@@ -38,4 +38,12 @@ class CleverCLITestCase(unittest.TestCase):
     # Check for no error when key is provided via CLEVER_API_KEY
     env = {'CLEVER_API_KEY':'DEMO_KEY'}
     out, err, code = self.run_clever('district all', env)
+    self.assertEqual(code, 0)
+
+  def test_query_params(self):
+    # Check for error when query param is invalid
+    out, err, code = self.run_clever('student all -k DEMO_KEY coun=true')
+    self.assertNotEqual(code, 0)
+    # Check for success when query param is valid
+    out, err, code = self.run_clever('student all -k DEMO_KEY count=true')
     self.assertEqual(code, 0)


### PR DESCRIPTION
*Note: This pull request depends on #29. Please discuss/merge it first... or whatever.*

The cli query params code was using `encode()`, but it was renamed to `urlencode()`. I wrote tests and discovered the script was returning 0 even when HTTP status wasn't 200. So, I fixed that.

Here is the error (generated using the working cli code in #29):
```
$ bin/clever student all -k DEMO_KEY count=true
Traceback (most recent call last):
  File "bin/clever", line 213, in <module>
    sys.exit(main())
  File "bin/clever", line 210, in main
    return method(params)
  File "bin/clever", line 85, in all
    self.logged_curl('get', url, params)
  File "bin/clever", line 29, in logged_curl
    self.log_request(method, url, params, dict_params)
  File "bin/clever", line 38, in log_request
    url = '%s?%s' % (url, clever.APIRequestor().encode(dict_params))
AttributeError: 'APIRequestor' object has no attribute 'encode'
```