### PR TITLE
Follow links

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,14 @@ If you'd like more control over pagination, or to limit the number of resources 
         print students.next()
 ```
 
+You may also use the `starting_after` or `ending_before` parameters with the `iter` method:
+
+```python
+    students = clever.Student.iter(starting_after="530e5960049e75a9262cff1d")
+    for s in students:
+        print students.next()
+```
+
 The `retrieve` class method takes in a Clever ID and returns a specific resource. The object (or list of objects in the case of `all`) supports accessing properties using either dot notation or dictionary notation:
 
 ```python

--- a/clever/__init__.py
+++ b/clever/__init__.py
@@ -710,20 +710,21 @@ class ListableAPIResource(APIResource):
 
   @classmethod
   def iter(cls, auth=None, **params):
-    for unsupported_param in ['limit', 'page', 'starting_after', 'ending_before']:
+    for unsupported_param in ['limit', 'page']:
       if unsupported_param in params:
         raise CleverError("ListableAPIResource does not support '%s' parameter" %
                           (unsupported_param,))
 
     requestor = APIRequestor(auth)
     url = cls.class_url()
-    params['limit'] = cls.ITER_LIMIT
+    params['limit'] = cls.ITER_LIMIT    
 
     while url:
       response, auth = requestor.request('get', url, params)
       for datum in convert_to_clever_object(cls, response, auth):
         yield datum
-      url = get_link(response, 'next')
+      
+      url = get_link(response, 'prev' if 'ending_before' in params else 'next')
       # params already included in url from get_link
       params = {}
 


### PR DESCRIPTION
This PR fixes the existing broken tests and adds new tests for starting_before and ending_after params, which are now supported in the iter() method.