### PR TITLE
Fix pagination with parameters - urllib2 and urlfetch

### DIFF
--- a/clever/__init__.py
+++ b/clever/__init__.py
@@ -145,7 +145,7 @@ class TooManyRequestsError(CleverError):
 
 def convert_to_clever_object(klass, resp, auth):
   # TODO: to support includes we'll have to infer klass from resp['uri']
-  if isinstance(resp, dict) and resp.get('data', None):
+  if isinstance(resp, dict) and 'data' in resp:
     if isinstance(resp['data'], list):
       return [convert_to_clever_object(klass, i, auth) for i in resp['data']]
     elif isinstance(resp['data'], dict):

--- a/clever/__init__.py
+++ b/clever/__init__.py
@@ -457,7 +457,8 @@ class APIRequestor(object):
   def urllib2_request(self, meth, abs_url, headers, params):
     args = {}
     if meth == 'get':
-      abs_url = '%s?%s' % (abs_url, self.urlencode(params))
+      if params:
+        abs_url = '%s?%s' % (abs_url, self.urlencode(params))
       req = urllib2.Request(abs_url, None, headers)
     elif meth in ['post', 'patch']:
       body = self.jsonencode(params)

--- a/clever/__init__.py
+++ b/clever/__init__.py
@@ -414,7 +414,8 @@ class APIRequestor(object):
   def urlfetch_request(self, meth, abs_url, headers, params):
     args = {}
     if meth == 'get':
-      abs_url = '%s?%s' % (abs_url, self.urlencode(params))
+      if params:
+        abs_url = '%s?%s' % (abs_url, self.urlencode(params))
     elif meth in ['post', 'patch']:
       args['payload'] = self.jsonencode(params)
       headers['Content-Type'] = 'application/json'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 httmock>=1.2.2
 requests>=0.8.8
+urlfetch

--- a/test/test_clever.py
+++ b/test/test_clever.py
@@ -3,6 +3,7 @@ import os
 import sys
 import unittest
 import urllib2
+import urlfetch
 import httmock
 import itertools
 
@@ -142,23 +143,31 @@ class FunctionalTests(CleverTestCase):
     district = clever.District.all(where=json.dumps({'name': 'asdf'}))
     self.assertEqual(district, [])
 
-  def _set_httplib_urllib2(self):
-    clever.urllib2 = urllib2
-    clever._httplib = 'urllib2'
+class TransportDependentMixin:
 
   def test_pagination_urllib2(self):
-    self._set_httplib_urllib2()
     teachers = clever.Teacher.all()
     clever.ListableAPIResource.ITER_LIMIT = 40
     self.assertTrue(len(teachers) > clever.ListableAPIResource.ITER_LIMIT,
                     msg='Invalid test - did not cross pagination threshold')
 
   def test_pagination_urllib2_with_params(self):
-    self._set_httplib_urllib2()
     teachers = clever.Teacher.all(where='{"name.first": {"$gte": "A"}}')
     clever.ListableAPIResource.ITER_LIMIT = 40
     self.assertTrue(len(teachers) > clever.ListableAPIResource.ITER_LIMIT,
                     msg='Invalid test - did not cross pagination threshold')
+
+
+class Urllib2Test(CleverTestCase, TransportDependentMixin):
+  def setUp(self):
+    clever.urllib2 = urllib2
+    clever._httplib = 'urllib2'
+
+class UrlfetchTest(CleverTestCase, TransportDependentMixin):
+  def setUp(self):
+    clever.urlfetch = urlfetch
+    clever._httplib = 'urlfetch'
+
 
 
 class AuthenticationErrorTest(CleverTestCase):

--- a/test/test_clever.py
+++ b/test/test_clever.py
@@ -2,6 +2,7 @@
 import os
 import sys
 import unittest
+import urllib2
 import httmock
 import itertools
 
@@ -140,6 +141,25 @@ class FunctionalTests(CleverTestCase):
   def test_empty_list_on_no_data(self):
     district = clever.District.all(where=json.dumps({'name': 'asdf'}))
     self.assertEqual(district, [])
+
+  def _set_httplib_urllib2(self):
+    clever.urllib2 = urllib2
+    clever._httplib = 'urllib2'
+
+  def test_pagination_urllib2(self):
+    self._set_httplib_urllib2()
+    teachers = clever.Teacher.all()
+    clever.ListableAPIResource.ITER_LIMIT = 40
+    self.assertTrue(len(teachers) > clever.ListableAPIResource.ITER_LIMIT,
+                    msg='Invalid test - did not cross pagination threshold')
+
+  def test_pagination_urllib2_with_params(self):
+    self._set_httplib_urllib2()
+    teachers = clever.Teacher.all(where='{"name.first": {"$gte": "A"}}')
+    clever.ListableAPIResource.ITER_LIMIT = 40
+    self.assertTrue(len(teachers) > clever.ListableAPIResource.ITER_LIMIT,
+                    msg='Invalid test - did not cross pagination threshold')
+
 
 class AuthenticationErrorTest(CleverTestCase):
 


### PR DESCRIPTION
Pagination was breaking.  The iterator clears the params because they are embedded in the next/prev links in the current response, but the empty params are still appended leading to two question marks in the URL.

The request methods for two of the four http libraries already had a check for empty params, but these two did not.

NB: The unit tests did not all work for me out of the box.  I did not change any existing tests.
